### PR TITLE
Feat: Use pre-calculated ConstraintMatrices 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [pull_request, push]
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
 
 name: Tests
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ark-ec = { version = "0.3.0", default-features = false }
 ark-ff = { version = "0.3.0", default-features = false }
 ark-std = { version = "0.3.0", default-features = false }
 ark-bn254 = { version = "0.3.0" }
-ark-groth16 = { git = "https://github.com/gakonst/groth16", version = "0.3.0", branch = "feat/customizable-r1cs-to-qap" }
+ark-groth16 = { git = "https://github.com/gakonst/groth16", version = "0.3.0", branch = "calculate-matrices" }
 ark-poly = { version = "^0.3.0", default-features = false }
 ark-relations = { version = "0.3.0", default-features = false }
 ark-serialize = { version = "0.3.0", default-features = false }

--- a/src/circom/builder.rs
+++ b/src/circom/builder.rs
@@ -77,7 +77,7 @@ impl<E: PairingEngine> CircomBuilder<E> {
             .wtns
             .calculate_witness(self.inputs, self.cfg.sanity_check)?;
 
-        use ark_ff::{PrimeField, FpParameters};
+        use ark_ff::{FpParameters, PrimeField};
         let modulus = <<E::Fr as PrimeField>::Params as FpParameters>::MODULUS;
 
         // convert it to field elements
@@ -92,7 +92,8 @@ impl<E: PairingEngine> CircomBuilder<E> {
                     w.to_biguint().unwrap()
                 };
                 E::Fr::from(w)
-            }).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
         circom.witness = Some(witness);
 
         // sanity check

--- a/src/circom/builder.rs
+++ b/src/circom/builder.rs
@@ -75,25 +75,7 @@ impl<E: PairingEngine> CircomBuilder<E> {
         let witness = self
             .cfg
             .wtns
-            .calculate_witness(self.inputs, self.cfg.sanity_check)?;
-
-        use ark_ff::{FpParameters, PrimeField};
-        let modulus = <<E::Fr as PrimeField>::Params as FpParameters>::MODULUS;
-
-        // convert it to field elements
-        use num_traits::Signed;
-        let witness = witness
-            .into_iter()
-            .map(|w| {
-                let w = if w.sign() == num_bigint::Sign::Minus {
-                    // Need to negate the witness element if negative
-                    modulus.into() - w.abs().to_biguint().unwrap()
-                } else {
-                    w.to_biguint().unwrap()
-                };
-                E::Fr::from(w)
-            })
-            .collect::<Vec<_>>();
+            .calculate_witness_element::<E, _>(self.inputs, self.cfg.sanity_check)?;
         circom.witness = Some(witness);
 
         // sanity check

--- a/src/circom/qap.rs
+++ b/src/circom/qap.rs
@@ -39,8 +39,8 @@ impl R1CStoQAP for CircomReduction {
             .zip(cfg_iter!(&matrices.a))
             .zip(cfg_iter!(&matrices.b))
             .for_each(|(((a, b), at_i), bt_i)| {
-                *a = evaluate_constraint(at_i, &full_assignment);
-                *b = evaluate_constraint(bt_i, &full_assignment);
+                *a = evaluate_constraint(at_i, full_assignment);
+                *b = evaluate_constraint(bt_i, full_assignment);
             });
 
         {

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -2,8 +2,9 @@
 //! Solidity Groth16 Verifier smart contracts
 use ark_ff::{BigInteger, FromBytes, PrimeField};
 use ethers_core::types::U256;
+use num_traits::Zero;
 
-use ark_bn254::{Bn254, Fq2, Fr, G1Affine, G2Affine};
+use ark_bn254::{Bn254, Fq, Fq2, Fr, G1Affine, G2Affine};
 
 pub struct Inputs(pub Vec<U256>);
 
@@ -23,9 +24,10 @@ pub struct G1 {
 
 impl From<G1> for G1Affine {
     fn from(src: G1) -> G1Affine {
-        let x = u256_to_point(src.x);
-        let y = u256_to_point(src.y);
-        G1Affine::new(x, y, false)
+        let x: Fq = u256_to_point(src.x);
+        let y: Fq = u256_to_point(src.y);
+        let inf = x.is_zero() && y.is_zero();
+        G1Affine::new(x, y, inf)
     }
 }
 
@@ -62,7 +64,8 @@ impl From<G2> for G2Affine {
         let c1 = u256_to_point(src.y[1]);
         let y = Fq2::new(c0, c1);
 
-        G2Affine::new(x, y, false)
+        let inf = x.is_zero() && y.is_zero();
+        G2Affine::new(x, y, inf)
     }
 }
 

--- a/src/zkey.rs
+++ b/src/zkey.rs
@@ -152,6 +152,7 @@ impl<'a, R: Read + Seek> BinFile<'a, R> {
         let mut coeffs = vec![];
         for _ in 0..num_coeffs {
             let matrix: u32 = FromBytes::read(&mut self.reader)?;
+            dbg!(&matrix);
             let constraint: u32 = FromBytes::read(&mut self.reader)?;
             let signal: u32 = FromBytes::read(&mut self.reader)?;
             let value: Fq2 = deserialize_field2(&mut self.reader)?;
@@ -168,15 +169,21 @@ impl<'a, R: Read + Seek> BinFile<'a, R> {
         let a = vec![vec![(Fr::zero(), 0); 1]];
         let b = a.clone();
         let c = a.clone();
+
+        // This is taken from Arkworks' to_matrices() function
+        let a_num_non_zero: usize = a.iter().map(|lc| lc.len()).sum();
+        let b_num_non_zero: usize = b.iter().map(|lc| lc.len()).sum();
+        let c_num_non_zero: usize = c.iter().map(|lc| lc.len()).sum();
         let matrices = ConstraintMatrices {
             num_instance_variables: header.n_vars,
-            // How to set these?
+            // How many witness variables do we have? Is this correct?
             num_witness_variables: header.n_vars - header.n_public,
+            // How do we get num_constraints?
             num_constraints: 100,
 
-            a_num_non_zero: 0,
-            b_num_non_zero: 0,
-            c_num_non_zero: 0,
+            a_num_non_zero,
+            b_num_non_zero,
+            c_num_non_zero,
 
             a,
             b,

--- a/src/zkey.rs
+++ b/src/zkey.rs
@@ -526,18 +526,10 @@ mod tests {
     }
 
     #[test]
-    fn matrices_ok() {
-        let path = "./test-vectors/test.zkey";
-        let mut file = File::open(path).unwrap();
-        let (params, matrices) = read_zkey(&mut file).unwrap();
-        dbg!(&matrices);
-    }
-
-    #[test]
     fn deser_key() {
         let path = "./test-vectors/test.zkey";
         let mut file = File::open(path).unwrap();
-        let (params, matrices) = read_zkey(&mut file).unwrap();
+        let (params, _matrices) = read_zkey(&mut file).unwrap();
 
         // Check IC
         let expected = vec![
@@ -757,7 +749,7 @@ mod tests {
     fn deser_vk() {
         let path = "./test-vectors/test.zkey";
         let mut file = File::open(path).unwrap();
-        let (params, matrices) = read_zkey(&mut file).unwrap();
+        let (params, _matrices) = read_zkey(&mut file).unwrap();
 
         let json = std::fs::read_to_string("./test-vectors/verification_key.json").unwrap();
         let json: Value = serde_json::from_str(&json).unwrap();
@@ -838,7 +830,7 @@ mod tests {
     fn verify_proof_with_zkey_with_r1cs() {
         let path = "./test-vectors/test.zkey";
         let mut file = File::open(path).unwrap();
-        let (params, matrices) = read_zkey(&mut file).unwrap(); // binfile.proving_key().unwrap();
+        let (params, _matrices) = read_zkey(&mut file).unwrap(); // binfile.proving_key().unwrap();
 
         let cfg = CircomConfig::<Bn254>::new(
             "./test-vectors/mycircuit.wasm",

--- a/src/zkey.rs
+++ b/src/zkey.rs
@@ -36,7 +36,7 @@ use std::{
     io::{Read, Result as IoResult, Seek, SeekFrom},
 };
 
-use ark_bn254::{Bn254, Fq, Fq2, G1Affine, G2Affine, Fr};
+use ark_bn254::{Bn254, Fq, Fq2, Fr, G1Affine, G2Affine};
 use ark_groth16::{ProvingKey, VerifyingKey};
 use num_traits::Zero;
 

--- a/src/zkey.rs
+++ b/src/zkey.rs
@@ -148,6 +148,7 @@ impl<'a, R: Read + Seek> BinFile<'a, R> {
         self.reader.seek(SeekFrom::Start(section.position))?;
 
         let num_coeffs: u32 = FromBytes::read(&mut self.reader)?;
+        dbg!(&num_coeffs);
         let mut coeffs = vec![];
         for _ in 0..num_coeffs {
             let matrix: u32 = FromBytes::read(&mut self.reader)?;
@@ -159,6 +160,7 @@ impl<'a, R: Read + Seek> BinFile<'a, R> {
             // signal is column
             coeffs.push((matrix, constraint, signal, value));
         }
+        dbg!(&coeffs);
 
         let header = self.groth_header()?;
 
@@ -512,7 +514,7 @@ mod tests {
     fn deser_key() {
         let path = "./test-vectors/test.zkey";
         let mut file = File::open(path).unwrap();
-        let params = read_zkey(&mut file).unwrap();
+        let (params, matrices) = read_zkey(&mut file).unwrap();
 
         // Check IC
         let expected = vec![
@@ -732,7 +734,7 @@ mod tests {
     fn deser_vk() {
         let path = "./test-vectors/test.zkey";
         let mut file = File::open(path).unwrap();
-        let params = read_zkey(&mut file).unwrap();
+        let (params, matrices) = read_zkey(&mut file).unwrap();
 
         let json = std::fs::read_to_string("./test-vectors/verification_key.json").unwrap();
         let json: Value = serde_json::from_str(&json).unwrap();
@@ -813,7 +815,7 @@ mod tests {
     fn verify_proof_with_zkey() {
         let path = "./test-vectors/test.zkey";
         let mut file = File::open(path).unwrap();
-        let params = read_zkey(&mut file).unwrap(); // binfile.proving_key().unwrap();
+        let (params, matrices) = read_zkey(&mut file).unwrap(); // binfile.proving_key().unwrap();
 
         let cfg = CircomConfig::<Bn254>::new(
             "./test-vectors/mycircuit.wasm",

--- a/src/zkey.rs
+++ b/src/zkey.rs
@@ -522,6 +522,14 @@ mod tests {
     }
 
     #[test]
+    fn matrices_ok() {
+        let path = "./test-vectors/test.zkey";
+        let mut file = File::open(path).unwrap();
+        let (params, matrices) = read_zkey(&mut file).unwrap();
+        dbg!(&matrices);
+    }
+
+    #[test]
     fn deser_key() {
         let path = "./test-vectors/test.zkey";
         let mut file = File::open(path).unwrap();

--- a/tests/solidity.rs
+++ b/tests/solidity.rs
@@ -1,7 +1,4 @@
-use ark_circom::{
-    ethereum::{Inputs, Proof, VerifyingKey},
-    CircomBuilder, CircomConfig,
-};
+use ark_circom::{ethereum, CircomBuilder, CircomConfig};
 use ark_std::rand::thread_rng;
 use color_eyre::Result;
 
@@ -70,18 +67,59 @@ async fn solidity_verifier() -> Result<()> {
     Ok(())
 }
 
+// We need to implement the conversion from the Ark-Circom's internal Ethereum types to
+// the ones expected by the abigen'd types. Could we maybe provide a convenience
+// macro for these, given that there's room for implementation error?
 abigen!(Groth16Verifier, "./tests/verifier_abi.json");
+use groth16verifier_mod::{G1Point, G2Point, Proof, VerifyingKey};
+impl From<ethereum::G1> for G1Point {
+    fn from(src: ethereum::G1) -> Self {
+        Self { x: src.x, y: src.y }
+    }
+}
+impl From<ethereum::G2> for G2Point {
+    fn from(src: ethereum::G2) -> Self {
+        // We should use the `.as_tuple()` method which handles converting
+        // the G2 elements to have the second limb first
+        let src = src.as_tuple();
+        Self { x: src.0, y: src.1 }
+    }
+}
+impl From<ethereum::Proof> for Proof {
+    fn from(src: ethereum::Proof) -> Self {
+        Self {
+            a: src.a.into(),
+            b: src.b.into(),
+            c: src.c.into(),
+        }
+    }
+}
+impl From<ethereum::VerifyingKey> for VerifyingKey {
+    fn from(src: ethereum::VerifyingKey) -> Self {
+        Self {
+            alfa_1: src.alpha1.into(),
+            beta_2: src.beta2.into(),
+            gamma_2: src.gamma2.into(),
+            delta_2: src.delta2.into(),
+            ic: src.ic.into_iter().map(|i| i.into()).collect(),
+        }
+    }
+}
 
 impl<M: Middleware> Groth16Verifier<M> {
-    async fn check_proof<I: Into<Inputs>, P: Into<Proof>, VK: Into<VerifyingKey>>(
+    async fn check_proof<
+        I: Into<ethereum::Inputs>,
+        P: Into<ethereum::Proof>,
+        VK: Into<ethereum::VerifyingKey>,
+    >(
         &self,
         proof: P,
         vk: VK,
         inputs: I,
     ) -> Result<bool, ContractError<M>> {
         // convert into the expected format by the contract
-        let proof = proof.into().as_tuple();
-        let vk = vk.into().as_tuple();
+        let proof = proof.into().into();
+        let vk = vk.into().into();
         let inputs = inputs.into().0;
 
         // query the contract


### PR DESCRIPTION
Previously, we'd always need the R1CS file from Circom to calculate proofs. This is not necessary because SnarkJS' zkey file also contains the "coefficients", which we can construct the `ConstraintMatrices` from, and use them to generate a proof w/ them pre-computed using `generate_proof_with_qap_and_matrices`.

Also updates the tests to use the correct abi encoder v2 types in Solidity.