### PR TITLE
Early exit in error callback from Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: 
+    branches:
       - master
   pull_request:
 
@@ -34,6 +34,10 @@ jobs:
             chmod u+x "$HOME/bin/solc"
             export PATH=$HOME/bin:$PATH
             solc --version
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
 
       - name: cargo test
         run: |

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -2,7 +2,6 @@ use color_eyre::Result;
 use num_bigint::BigInt;
 use num_traits::Zero;
 use std::cell::Cell;
-use std::fmt;
 use wasmer::{imports, Function, Instance, Memory, MemoryType, Module, RuntimeError, Store};
 
 use super::{fnv, SafeMemory, Wasm};
@@ -16,16 +15,9 @@ pub struct WitnessCalculator {
 
 // Error type to signal end of execution.
 // From https://docs.wasmer.io/integrations/examples/exit-early
-#[derive(Debug, Clone, Copy)]
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+#[error("{0}")]
 struct ExitCode(u32);
-
-impl fmt::Display for ExitCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::error::Error for ExitCode {}
 
 impl WitnessCalculator {
     pub fn new(path: impl AsRef<std::path::Path>) -> Result<Self> {
@@ -161,8 +153,11 @@ mod runtime {
         fn func(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) {
             // NOTE: We can also get more information why it is failing, see p2str etc here:
             // https://github.com/iden3/circom_runtime/blob/master/js/witness_calculator.js#L52-L64
-           println!("runtime error, exiting early: {0} {1} {2} {3} {4} {5}", a, b, c, d, e, f);
-           RuntimeError::raise(Box::new(ExitCode(1)));
+            println!(
+                "runtime error, exiting early: {0} {1} {2} {3} {4} {5}",
+                a, b, c, d, e, f
+            );
+            RuntimeError::raise(Box::new(ExitCode(1)));
         }
         Function::new_native(store, func)
     }

--- a/tests/groth16.rs
+++ b/tests/groth16.rs
@@ -37,3 +37,31 @@ fn groth16_proof() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn groth16_proof_wrong_input() -> Result<()> {
+    let cfg = CircomConfig::<Bn254>::new(
+        "./test-vectors/mycircuit.wasm",
+        "./test-vectors/mycircuit.r1cs",
+    )?;
+    let mut builder = CircomBuilder::new(cfg);
+    builder.push_input("a", 3);
+    // This isn't a public input to the circuit, should faild
+    builder.push_input("foo", 11);
+
+    // create an empty instance for setting it up
+    let circom = builder.setup();
+
+    let mut rng = thread_rng();
+    let _params = generate_random_parameters::<Bn254, _, _>(circom, &mut rng)?;
+
+    match builder.build() {
+        Ok(_v) => {
+            panic!("Should't be able to calculate witness with wrong public input");
+        }
+        Err(_e) => {
+            // Wrong public input, unable to calculate witness as expected
+            return Ok(());
+        }
+    }
+}

--- a/tests/groth16.rs
+++ b/tests/groth16.rs
@@ -39,11 +39,12 @@ fn groth16_proof() -> Result<()> {
 }
 
 #[test]
-fn groth16_proof_wrong_input() -> Result<()> {
+fn groth16_proof_wrong_input() {
     let cfg = CircomConfig::<Bn254>::new(
         "./test-vectors/mycircuit.wasm",
         "./test-vectors/mycircuit.r1cs",
-    )?;
+    )
+    .unwrap();
     let mut builder = CircomBuilder::new(cfg);
     builder.push_input("a", 3);
     // This isn't a public input to the circuit, should faild
@@ -53,15 +54,7 @@ fn groth16_proof_wrong_input() -> Result<()> {
     let circom = builder.setup();
 
     let mut rng = thread_rng();
-    let _params = generate_random_parameters::<Bn254, _, _>(circom, &mut rng)?;
+    let _params = generate_random_parameters::<Bn254, _, _>(circom, &mut rng).unwrap();
 
-    match builder.build() {
-        Ok(_v) => {
-            panic!("Should't be able to calculate witness with wrong public input");
-        }
-        Err(_e) => {
-            // Wrong public input, unable to calculate witness as expected
-            return Ok(());
-        }
-    }
+    builder.build().unwrap_err();
 }


### PR DESCRIPTION
This avoids Wasm execution hanging due to problems such as wrong public input.

Mimics circom_runtime behaviour with less detailed debug information.

See https://github.com/iden3/circom_runtime/blob/master/js/witness_calculator.js#L52-L64

Adds test for wrong public input. Without early exit, the test stalls.
With it, the Circom build step fails as expected.