### PR TITLE
Improve r1cs_reader for Circom 2

### DIFF
--- a/src/circom/r1cs_reader.rs
+++ b/src/circom/r1cs_reader.rs
@@ -70,8 +70,7 @@ impl<E: PairingEngine> R1CSFile<E> {
         let mut sec_sizes = HashMap::<u32, u64>::new();
 
         // get file offset of each section
-        let v = vec![0; num_sections as usize];
-        for _ in v.iter() {
+        for _ in 0..num_sections {
             let sec_type = reader.read_u32::<LittleEndian>()?;
             let sec_size = reader.read_u64::<LittleEndian>()?;
             let offset = reader.seek(SeekFrom::Current(0))?;

--- a/src/circom/r1cs_reader.rs
+++ b/src/circom/r1cs_reader.rs
@@ -44,6 +44,11 @@ pub struct R1CSFile<E: PairingEngine> {
 }
 
 impl<E: PairingEngine> R1CSFile<E> {
+    /// reader must implement the Seek trait, for example with a Cursor
+    ///
+    /// ```rust,ignore
+    /// let reader = BufReader::new(Cursor::new(&data[..]));
+    /// ```
     pub fn new<R: Read + Seek>(mut reader: R) -> Result<R1CSFile<E>> {
         let mut magic = [0u8; 4];
         reader.read_exact(&mut magic)?;

--- a/src/circom/r1cs_reader.rs
+++ b/src/circom/r1cs_reader.rs
@@ -1,6 +1,6 @@
 //! R1CS circom file reader
-//! Copied from https://github.com/poma/zkutil
-//! Spec: https://github.com/iden3/r1csfile/blob/master/doc/r1cs_bin_format.md
+//! Copied from <https://github.com/poma/zkutil>
+//! Spec: <https://github.com/iden3/r1csfile/blob/master/doc/r1cs_bin_format.md>
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::io::{Error, ErrorKind, Result};
 

--- a/src/circom/r1cs_reader.rs
+++ b/src/circom/r1cs_reader.rs
@@ -70,7 +70,8 @@ impl<E: PairingEngine> R1CSFile<E> {
         let mut sec_sizes = HashMap::<u32, u64>::new();
 
         // get file offset of each section
-        for _ in 0..num_sections {
+        let v = vec![0; num_sections as usize];
+        for _ in v.iter() {
             let sec_type = reader.read_u32::<LittleEndian>()?;
             let sec_size = reader.read_u64::<LittleEndian>()?;
             let offset = reader.seek(SeekFrom::Current(0))?;


### PR DESCRIPTION
Continued progress towards https://github.com/gakonst/ark-circom/issues/8

Shamelessly taken from https://github.com/poma/zkutil/pull/7/files by @lispc

cc @gakonst 

Next step is improving WASM coverage.