### PR TITLE
circom2 proof generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # WASM operations
 wasmer = { version = "2.0" }
 fnv = { version = "1.0.3", default-features = false }
-num = "0.4.0"
+num = { version = "0.4.0" }
 num-traits = { version = "0.2.0", default-features = false }
 num-bigint = { version = "0.4", default-features = false, features = ["rand"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # WASM operations
 wasmer = { version = "2.0" }
 fnv = { version = "1.0.3", default-features = false }
+num = "0.4.0"
 num-traits = { version = "0.2.0", default-features = false }
 num-bigint = { version = "0.4", default-features = false, features = ["rand"] }
 

--- a/src/witness/circom.rs
+++ b/src/witness/circom.rs
@@ -31,6 +31,10 @@ pub trait Circom2 {
     fn get_field_num_len32(&self) -> Result<i32>;
     fn get_raw_prime(&self) -> Result<()>;
     fn read_shared_rw_memory(&self, i: i32) -> Result<i32>;
+    fn write_shared_rw_memory(&self, i: i32, v: i32) -> Result<()>;
+    fn set_input_signal(&self, hmsb: i32, hlsb: i32, pos: i32) -> Result<()>;
+    fn get_witness(&self, i: i32) -> Result<()>;
+    fn get_witness_size(&self) -> Result<i32>;
 }
 
 #[cfg(not(feature = "circom-2"))]
@@ -63,6 +67,30 @@ impl Circom2 for Wasm {
     fn read_shared_rw_memory(&self, i: i32) -> Result<i32> {
         let func = self.func("readSharedRWMemory");
         let result = func.call(&[i.into()])?;
+        Ok(result[0].unwrap_i32())
+    }
+
+    fn write_shared_rw_memory(&self, i: i32, v: i32) -> Result<()> {
+        let func = self.func("writeSharedRWMemory");
+        let result = func.call(&[i.into(), v.into()])?;
+        Ok(())
+    }
+
+    fn set_input_signal(&self, hmsb: i32, hlsb: i32, pos: i32) -> Result<()> {
+        let func = self.func("setInputSignal");
+        let result = func.call(&[hmsb.into(), hlsb.into(), pos.into()])?;
+        Ok(())
+    }
+
+    fn get_witness(&self, i: i32) -> Result<()> {
+        let func = self.func("getWitness");
+        let result = func.call(&[i.into()])?;
+        Ok(())
+    }
+
+    fn get_witness_size(&self) -> Result<i32> {
+        let func = self.func("getWitnessSize");
+        let result = func.call(&[])?;
         Ok(result[0].unwrap_i32())
     }
 }

--- a/src/witness/circom.rs
+++ b/src/witness/circom.rs
@@ -60,7 +60,7 @@ impl Circom2 for Wasm {
 
     fn get_raw_prime(&self) -> Result<()> {
         let func = self.func("getRawPrime");
-        let _result = func.call(&[])?;
+        func.call(&[])?;
         Ok(())
     }
 
@@ -72,19 +72,19 @@ impl Circom2 for Wasm {
 
     fn write_shared_rw_memory(&self, i: i32, v: i32) -> Result<()> {
         let func = self.func("writeSharedRWMemory");
-        let result = func.call(&[i.into(), v.into()])?;
+        func.call(&[i.into(), v.into()])?;
         Ok(())
     }
 
     fn set_input_signal(&self, hmsb: i32, hlsb: i32, pos: i32) -> Result<()> {
         let func = self.func("setInputSignal");
-        let result = func.call(&[hmsb.into(), hlsb.into(), pos.into()])?;
+        func.call(&[hmsb.into(), hlsb.into(), pos.into()])?;
         Ok(())
     }
 
     fn get_witness(&self, i: i32) -> Result<()> {
         let func = self.func("getWitness");
-        let result = func.call(&[i.into()])?;
+        func.call(&[i.into()])?;
         Ok(())
     }
 

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -1,5 +1,6 @@
 use super::{fnv, CircomBase, SafeMemory, Wasm};
 use color_eyre::Result;
+use num::ToPrimitive;
 use num_bigint::BigInt;
 use num_traits::Zero;
 use std::cell::Cell;
@@ -35,7 +36,6 @@ fn from_array32(arr: Vec<i32>) -> BigInt {
 }
 
 #[cfg(feature = "circom-2")]
-use num::ToPrimitive;
 
 fn to_array32(s: &BigInt, size: usize) -> Vec<i32> {
     let mut res = vec![0; size as usize];
@@ -118,7 +118,7 @@ impl WitnessCalculator {
         sanity_check: bool,
     ) -> Result<Vec<BigInt>> {
         self.instance.init(sanity_check)?;
-        
+
         cfg_if::cfg_if! {
             if #[cfg(feature = "circom-2")] {
                 let n32 = self.instance.get_field_num_len32()?;
@@ -132,7 +132,7 @@ impl WitnessCalculator {
         // allocate the inputs
         for (name, values) in inputs.into_iter() {
             let (msb, lsb) = fnv(&name);
-            
+
             cfg_if::cfg_if! {
                 if #[cfg(feature = "circom-2")] {
                     for (i, value) in values.into_iter().enumerate() {
@@ -162,7 +162,6 @@ impl WitnessCalculator {
         cfg_if::cfg_if! {
             if #[cfg(feature = "circom-2")] {
                 let witness_size = self.instance.get_witness_size()?;
-
                 for i in 0..witness_size {
                     self.instance.get_witness(i);
                     let mut arr = vec![0; n32 as usize];

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -1,10 +1,12 @@
 use super::{fnv, CircomBase, SafeMemory, Wasm};
 use color_eyre::Result;
-use num::ToPrimitive;
 use num_bigint::BigInt;
 use num_traits::Zero;
 use std::cell::Cell;
 use wasmer::{imports, Function, Instance, Memory, MemoryType, Module, RuntimeError, Store};
+
+#[cfg(feature = "circom-2")]
+use num::ToPrimitive;
 
 #[cfg(feature = "circom-2")]
 use super::Circom2;
@@ -36,7 +38,6 @@ fn from_array32(arr: Vec<i32>) -> BigInt {
 }
 
 #[cfg(feature = "circom-2")]
-
 fn to_array32(s: &BigInt, size: usize) -> Vec<i32> {
     let mut res = vec![0; size as usize];
     let mut rem = s.clone();

--- a/src/zkey.rs
+++ b/src/zkey.rs
@@ -43,6 +43,7 @@ use num_traits::Zero;
 #[derive(Clone, Debug)]
 struct Section {
     position: u64,
+    #[allow(dead_code)]
     size: usize,
 }
 
@@ -58,7 +59,9 @@ pub fn read_zkey<R: Read + Seek>(
 
 #[derive(Debug)]
 struct BinFile<'a, R> {
+    #[allow(dead_code)]
     ftype: String,
+    #[allow(dead_code)]
     version: u32,
     sections: HashMap<u32, Vec<Section>>,
     reader: &'a mut R,
@@ -255,16 +258,20 @@ impl ZVerifyingKey {
 
 #[derive(Clone, Debug)]
 struct HeaderGroth {
+    #[allow(dead_code)]
     n8q: u32,
+    #[allow(dead_code)]
     q: BigInteger256,
-
+    #[allow(dead_code)]
     n8r: u32,
+    #[allow(dead_code)]
     r: BigInteger256,
 
     n_vars: usize,
     n_public: usize,
 
     domain_size: u32,
+    #[allow(dead_code)]
     power: u32,
 
     verifying_key: ZVerifyingKey,


### PR DESCRIPTION
Continuing #10 
Circom2 groth16 proof generation is now working, implemented a few missing functions from the spec [here](https://docs.google.com/document/d/1P0j9zXjJRkhnyPT03VjxYBUySC8l4k41ZQ5LY7uyQnw/edit).
Testcase also succeeds now:  `cargo test --features circom-2 groth16_proof_circom2`