### PR TITLE
Ensure Circom 1 tests pass with experimental Circom 2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
             export PATH=$HOME/bin:$PATH
             cargo test
 
+      - name: cargo test circom 2 feature flag
+        run: |
+            export PATH=$HOME/bin:$PATH
+            cargo test --features circom-2
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "fnv",
  "hex",
  "hex-literal",
+ "num",
  "num-bigint",
  "num-traits",
  "serde_json",
@@ -1951,6 +1952,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,12 +1978,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 

--- a/src/witness/circom.rs
+++ b/src/witness/circom.rs
@@ -19,6 +19,8 @@ pub trait CircomBase {
     ) -> Result<()>;
     fn set_signal(&self, c_idx: i32, component: i32, signal: i32, p_val: i32) -> Result<()>;
     fn get_i32(&self, name: &str) -> Result<i32>;
+    // Only exists natively in Circom2, hardcoded for Circom
+    fn get_version(&self) -> Result<i32>;
 }
 
 pub trait Circom {
@@ -27,7 +29,7 @@ pub trait Circom {
 }
 
 pub trait Circom2 {
-    fn get_version(&self) -> Result<i32>;
+//    fn get_version(&self) -> Result<i32>;
     fn get_field_num_len32(&self) -> Result<i32>;
     fn get_raw_prime(&self) -> Result<()>;
     fn read_shared_rw_memory(&self, i: i32) -> Result<i32>;
@@ -37,8 +39,8 @@ pub trait Circom2 {
     fn get_witness_size(&self) -> Result<i32>;
 }
 
-#[cfg(not(feature = "circom-2"))]
 impl Circom for Wasm {
+
     fn get_fr_len(&self) -> Result<i32> {
         self.get_i32("getFrLen")
     }
@@ -50,9 +52,6 @@ impl Circom for Wasm {
 
 #[cfg(feature = "circom-2")]
 impl Circom2 for Wasm {
-    fn get_version(&self) -> Result<i32> {
-        self.get_i32("getVersion")
-    }
 
     fn get_field_num_len32(&self) -> Result<i32> {
         self.get_i32("getFieldNumLen32")
@@ -140,6 +139,14 @@ impl CircomBase for Wasm {
         func.call(&[c_idx.into(), component.into(), signal.into(), p_val.into()])?;
 
         Ok(())
+    }
+
+    // Default to version 1 if it isn't explicitly defined
+    fn get_version(&self) -> Result<i32> {
+        match self.0.exports.get_function("getVersion") {
+            Ok(func) => Ok(func.call(&[])?[0].unwrap_i32()),
+            Err(_) => Ok(1)
+        }
     }
 
     fn get_i32(&self, name: &str) -> Result<i32> {

--- a/src/witness/circom.rs
+++ b/src/witness/circom.rs
@@ -29,7 +29,6 @@ pub trait Circom {
 }
 
 pub trait Circom2 {
-//    fn get_version(&self) -> Result<i32>;
     fn get_field_num_len32(&self) -> Result<i32>;
     fn get_raw_prime(&self) -> Result<()>;
     fn read_shared_rw_memory(&self, i: i32) -> Result<i32>;
@@ -40,7 +39,6 @@ pub trait Circom2 {
 }
 
 impl Circom for Wasm {
-
     fn get_fr_len(&self) -> Result<i32> {
         self.get_i32("getFrLen")
     }
@@ -52,7 +50,6 @@ impl Circom for Wasm {
 
 #[cfg(feature = "circom-2")]
 impl Circom2 for Wasm {
-
     fn get_field_num_len32(&self) -> Result<i32> {
         self.get_i32("getFieldNumLen32")
     }
@@ -145,7 +142,7 @@ impl CircomBase for Wasm {
     fn get_version(&self) -> Result<i32> {
         match self.0.exports.get_function("getVersion") {
             Ok(func) => Ok(func.call(&[])?[0].unwrap_i32()),
-            Err(_) => Ok(1)
+            Err(_) => Ok(1),
         }
     }
 

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -10,7 +10,6 @@ pub(super) use circom::{CircomBase, Wasm};
 #[cfg(feature = "circom-2")]
 pub(super) use circom::Circom2;
 
-#[cfg(not(feature = "circom-2"))]
 pub(super) use circom::Circom;
 
 use fnv::FnvHasher;

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -127,6 +127,13 @@ impl WitnessCalculator {
             })
         }
 
+        // Three possibilities:
+        // a) Circom 2 feature flag enabled, WASM runtime version 2
+        // b) Circom 2 feature flag enabled, WASM runtime version 1
+        // c) Circom 1 default behavior
+        //
+        // Once Circom 2 support is more stable, feature flag can be removed
+
         cfg_if::cfg_if! {
             if #[cfg(feature = "circom-2")] {
                 match version {
@@ -146,13 +153,6 @@ impl WitnessCalculator {
         sanity_check: bool,
     ) -> Result<Vec<BigInt>> {
         self.instance.init(sanity_check)?;
-
-        // Three possibilities:
-        // a) Circom 2 feature flag enabled, WASM runtime version 2
-        // b) Circom 2 feature flag enabled, WASM runtime version 1
-        // c) Circom 1 default behavior
-        //
-        // Once Circom 2 support is more stable, feature flag can be removed
 
         cfg_if::cfg_if! {
             if #[cfg(feature = "circom-2")] {

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -81,9 +81,8 @@ impl WitnessCalculator {
 
         match instance.get_version() {
             Ok(v) => version = v,
-            Err(_) => version = 1
+            Err(_) => version = 1,
         }
-
 
         // Circom 2 feature flag with version 2
         #[cfg(feature = "circom-2")]
@@ -167,7 +166,6 @@ impl WitnessCalculator {
         }
     }
 
-
     // Circom 1 default behavior
     fn calculate_witness_circom1<I: IntoIterator<Item = (String, Vec<BigInt>)>>(
         &mut self,
@@ -228,9 +226,13 @@ impl WitnessCalculator {
             for (i, value) in values.into_iter().enumerate() {
                 let f_arr = to_array32(&value, n32 as usize);
                 for j in 0..n32 {
-                    self.instance.write_shared_rw_memory(j as i32, f_arr[(n32 as usize) - 1 - (j as usize)])?;
+                    self.instance.write_shared_rw_memory(
+                        j as i32,
+                        f_arr[(n32 as usize) - 1 - (j as usize)],
+                    )?;
                 }
-                self.instance.set_input_signal(msb as i32, lsb as i32, i as i32)?;
+                self.instance
+                    .set_input_signal(msb as i32, lsb as i32, i as i32)?;
             }
         }
 
@@ -241,7 +243,7 @@ impl WitnessCalculator {
             self.instance.get_witness(i)?;
             let mut arr = vec![0; n32 as usize];
             for j in 0..n32 {
-                arr[(n32 as usize) - 1- (j as usize)] = self.instance.read_shared_rw_memory(j)?;
+                arr[(n32 as usize) - 1 - (j as usize)] = self.instance.read_shared_rw_memory(j)?;
             }
             w.push(from_array32(arr));
         }

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -142,7 +142,7 @@ impl WitnessCalculator {
                     _ => panic!("Unknown Circom version")
                 }
             } else {
-                new_circom1(instance, memory, version),
+                new_circom1(instance, memory, version)
             }
         }
     }
@@ -162,7 +162,7 @@ impl WitnessCalculator {
                     _ => panic!("Unknown Circom version")
                 }
             } else {
-                self.calculate_witness_circom1(inputs, sanity_check);
+                self.calculate_witness_circom1(inputs, sanity_check)
             }
         }
     }

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -54,7 +54,6 @@ fn to_array32(s: &BigInt, size: usize) -> Vec<i32> {
 
 impl WitnessCalculator {
     pub fn new(path: impl AsRef<std::path::Path>) -> Result<Self> {
-        println!("WitnessCalculator new");
         let store = Store::default();
         let module = Module::from_file(&store, path)?;
 
@@ -85,19 +84,15 @@ impl WitnessCalculator {
             Err(_) => version = 1
         }
 
-        println!("Version {:}", version);
-
         let n32;
         let mut safe_memory;
         let prime;
 
         cfg_if::cfg_if! {
             if #[cfg(feature = "circom-2")] {
-                println!("WitnessCalculator circom2 feature");
 
                 // Only enable if feature flag is enabled and Circom version is right
                 if version == 2 {
-                    println!("WitnessCalculator version 2");
                     n32 = instance.get_field_num_len32()?;
                     safe_memory = SafeMemory::new(memory, n32 as usize, BigInt::zero());
                     instance.get_raw_prime()?;
@@ -109,7 +104,6 @@ impl WitnessCalculator {
                     prime = from_array32(arr);
                 } else {
                     // Fallback to Circom 1 behavior
-                    println!("WitnessCalculator version 1");
                     n32 = (instance.get_fr_len()? >> 2) - 2;
                     safe_memory = SafeMemory::new(memory, n32 as usize, BigInt::zero());
                     let ptr = instance.get_ptr_raw_prime()?;
@@ -117,7 +111,6 @@ impl WitnessCalculator {
                 }
             } else {
                 // Fallback to Circom 1 behavior
-                println!("WitnessCalculator no circom2 feature");
                 n32 = (instance.get_fr_len()? >> 2) - 2;
                 safe_memory = SafeMemory::new(memory, n32 as usize, BigInt::zero());
                 let ptr = instance.get_ptr_raw_prime()?;
@@ -244,10 +237,6 @@ impl WitnessCalculator {
 
         Ok(w)
     }
-
-
-    ///
-    ///
 
     pub fn calculate_witness_element<
         E: ark_ec::PairingEngine,


### PR DESCRIPTION
This PR ensures all tests pass, regardless of if `circom-2` feature flag is enabled or not.

Since Circom v2 support is still experimental, the feature flag is still there. Once it has been proven to work, we can remove the flag completely. With this PR we can enable CI to test Circom 2 paths, see https://github.com/gakonst/ark-circom/issues/15

With Circom 2 flag enabled, the version is set to either (1) what getVersion returns, or (2) defaults 1, since getVersion isn't implemented in Circom 1 WASM interface.

Parent issue: https://github.com/gakonst/ark-circom/issues/8

## To test

```
cargo test
cargo test --features circom-2
```

## Note

I couldn't figure out how to do both compile time check for feature flag with `cfg_if` and normal runtime check of WASM version. Hence nested if statement and helper functions to avoid code duplication of the two actual code paths. https://github.com/gakonst/ark-circom/pull/18/files#diff-d0bf3370220b21ebe5cbae1064dbf8a93524e8b002f73bd30974c4f1ca28cea7R129

---

Update: closes https://github.com/gakonst/ark-circom/issues/15