### PR TITLE
When constraints are unsatisfied, show first constraint not satisfied

### DIFF
--- a/src/circom/builder.rs
+++ b/src/circom/builder.rs
@@ -83,7 +83,15 @@ impl<E: PairingEngine> CircomBuilder<E> {
             use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
             let cs = ConstraintSystem::<E::Fr>::new_ref();
             circom.clone().generate_constraints(cs.clone()).unwrap();
-            cs.is_satisfied().unwrap()
+            let is_satisfied = cs.is_satisfied().unwrap();
+            if !is_satisfied {
+                println!(
+                    "Unsatisfied constraint: {:?}",
+                    cs.which_is_unsatisfied().unwrap()
+                );
+            }
+
+            is_satisfied
         });
 
         Ok(circom)


### PR DESCRIPTION
Useful for debugging.

Ideally `ConstraintLayer` would work for tracing but I haven't managed to get it to work (https://github.com/vacp2p/zerokit/issues/3)

Now when a constraint fails leading to `debug_assert` we get:

```
Unsatisfied constraint: Some("3")
thread 'main' panicked at 'assertion failed: {\n    use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};\n    let cs = ConstraintSystem::<E::Fr>::new_ref();\n    circom.clone().generate_constraints(cs.clone()).unwrap();\n    let is_satisfied = cs.is_satisfied().unwrap();\n    if !is_satisfied {\n        println!(\"Unsatisfied constraint: {:?}\",\n                 cs.which_is_unsatisfied().unwrap());\n    }\n    is_satisfied\n}', /home/oskarth/repos/github.com/gakonst/ark-circom/src/circom/builder.rs:82:9
```

cc @gakonst 