### PR TITLE
feat: allow WitnessCalculator construction from wasmer::Module

### DIFF
--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -67,7 +67,7 @@ impl WitnessCalculator {
         let store = module.store();
 
         // Set up the memory
-        let memory = Memory::new(&store, MemoryType::new(2000, None, false)).unwrap();
+        let memory = Memory::new(store, MemoryType::new(2000, None, false)).unwrap();
         let import_object = imports! {
             "env" => {
                 "memory" => memory.clone(),

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -54,8 +54,17 @@ fn to_array32(s: &BigInt, size: usize) -> Vec<u32> {
 
 impl WitnessCalculator {
     pub fn new(path: impl AsRef<std::path::Path>) -> Result<Self> {
+        Self::from_file(path)
+    }
+
+    pub fn from_file(path: impl AsRef<std::path::Path>) -> Result<Self> {
         let store = Store::default();
         let module = Module::from_file(&store, path)?;
+        Self::from_module(module)
+    }
+
+    pub fn from_module(module: Module) -> Result<Self> {
+        let store = module.store();
 
         // Set up the memory
         let memory = Memory::new(&store, MemoryType::new(2000, None, false)).unwrap();
@@ -65,14 +74,14 @@ impl WitnessCalculator {
             },
             // Host function callbacks from the WASM
             "runtime" => {
-                "error" => runtime::error(&store),
-                "logSetSignal" => runtime::log_signal(&store),
-                "logGetSignal" => runtime::log_signal(&store),
-                "logFinishComponent" => runtime::log_component(&store),
-                "logStartComponent" => runtime::log_component(&store),
-                "log" => runtime::log_component(&store),
-                "exceptionHandler" => runtime::exception_handler(&store),
-                "showSharedRWMemory" => runtime::show_memory(&store),
+                "error" => runtime::error(store),
+                "logSetSignal" => runtime::log_signal(store),
+                "logGetSignal" => runtime::log_signal(store),
+                "logFinishComponent" => runtime::log_component(store),
+                "logStartComponent" => runtime::log_component(store),
+                "log" => runtime::log_component(store),
+                "exceptionHandler" => runtime::exception_handler(store),
+                "showSharedRWMemory" => runtime::show_memory(store),
             }
         };
         let instance = Wasm::new(Instance::new(&module, &import_object)?);


### PR DESCRIPTION
Currently `WtinessCalculator` can only be created from a file supplied by path.

This makes it awkward to bundle witness calculator wasm in a project, [example](https://github.com/worldcoin/semaphore-rs/blob/942880b27f54b20b31d036324926066134c12ec0/src/circuit.rs#L19). By allowing construction directly from `Module` wasm can be provided in any way wasmer supports. (i.e. `AsRef<[u8]>` , `&[u8]`, `AsRef<Path>`, etc.)

The original `new` constructor is left for compatibility, two new constructors `from_file` and `from_module` are added to disambiguate.

Another change is that the `store` ref for the imports is now taken to be `module.store()`. I assume this is correct.