### PR TITLE
feat!: use ruint & alloy for ethereum compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ thiserror = "1.0.39"
 color-eyre = "0.6.2"
 
 # ethereum compat
-ruint = { version = "1.12.3", default-features = false ,optional = true, features=["ark-ff-04"] }
+ruint = { version = "1.12.3", default-features = false ,optional = true, features=["alloc", "ark-ff-04"] }
 
 cfg-if = "1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,13 @@ ark-serialize = { version = "0.4.2", default-features = false }
 hex = "0.4.3"
 byteorder = "1.4.3"
 
-# ethereum compat
-ethers-core = { version = "2.0.7", default-features = false, optional = true }
 
 # error handling
 thiserror = "1.0.39"
 color-eyre = "0.6.2"
+
+# ethereum compat
+ruint = { version = "1.12.3", default-features = false ,optional = true, features=["ark-ff-04"] }
 
 cfg-if = "1.0.0"
 
@@ -47,7 +48,7 @@ criterion = "0.5.1"
 hex-literal = "0.4.1"
 tokio = { version = "1.29.1", features = ["macros"] }
 serde_json = "1.0.94"
-ethers = "2.0.7"
+alloy = { version = "0.6.4", default-features = false, features = ["contract", "node-bindings"] }
 
 [[bench]]
 name = "groth16"
@@ -58,4 +59,4 @@ default = ["wasmer/default", "circom-2", "ethereum"]
 wasm = ["wasmer/js-default"]
 bench-complex-all = []
 circom-2 = []
-ethereum = ["ethers-core"]
+ethereum = ["ruint"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Arkworks bindings to Circom's R1CS, for Groth16 Proof and Witness generation in Rust.
 
-![Github Actions](https://github.com/gakonst/ark-circom/workflows/Tests/badge.svg)
+![Github Actions](https://github.com/arkworks-rs/circom-compat/workflows/Tests/badge.svg)
 
 ## Documentation
 
@@ -13,7 +13,7 @@ Clone the repository and run `cd ark-circom/ && cargo doc --open`
 ```toml
 [dependencies]
 
-ark-circom = { git = "https://github.com/gakonst/ark-circom.git" }
+ark-circom = { git = "https://github.com/arkworks-rs/ark-circom.git" }
 ```
 
 ## Example
@@ -55,8 +55,7 @@ assert!(verified);
 
 Tests require the following installed:
 
-1. [`solc`](https://solidity.readthedocs.io/en/latest/installing-solidity.html). We also recommend using [solc-select](https://github.com/crytic/solc-select) for more flexibility.
-2. [`ganache-cli`](https://github.com/trufflesuite/ganache-cli#installation)
+1. [`anvil`](https://book.getfoundry.sh/getting-started/installation).
 
 ## Features
 

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -1,11 +1,11 @@
 //! Helpers for converting Arkworks types to U256-tuples as expected by the
 //! Solidity Groth16 Verifier smart contracts
 use ark_ff::{BigInteger, PrimeField};
-use ethers_core::types::U256;
 use num_traits::Zero;
 
 use ark_bn254::{Bn254, Fq, Fq2, Fr, G1Affine, G2Affine};
 use ark_serialize::CanonicalDeserialize;
+use ruint::aliases::U256;
 
 pub struct Inputs(pub Vec<U256>);
 
@@ -174,8 +174,7 @@ impl From<VerifyingKey> for ark_groth16::VerifyingKey<Bn254> {
 
 // Helper for converting a PrimeField to its U256 representation for Ethereum compatibility
 fn u256_to_point<F: PrimeField>(point: U256) -> F {
-    let mut buf = [0; 32];
-    point.to_little_endian(&mut buf);
+    let buf: [u8; 32] = point.to_le_bytes();
     let bigint = F::BigInt::deserialize_uncompressed(&buf[..]).expect("always works");
     F::from_bigint(bigint).expect("always works")
 }
@@ -185,7 +184,7 @@ fn u256_to_point<F: PrimeField>(point: U256) -> F {
 fn point_to_u256<F: PrimeField>(point: F) -> U256 {
     let point = point.into_bigint();
     let point_bytes = point.to_bytes_be();
-    U256::from(&point_bytes[..])
+    U256::try_from_be_slice(&point_bytes[..]).expect("always works")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Removes dependency on ethers which is now deprecated.
- Uses [ruint](https://github.com/recmo/uint)'s `U256` directly, which alloy uses under the hood. This poses a minor **breaking change** for the Ethereum compatibility module because previously the output was a uint (different crate) coming from ethers-core.
- Updates tests to use alloy instead of ethers.
- Very minor updates to the README that seem outdated.