### PR TITLE
Fix dependency building issues related to `wasm`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,19 @@ jobs:
           override: true
           target: wasm32-wasip1
       - name: Check wasm32-wasip compilation
-        run: cargo check --target wasm32-wasip1 --no-default-features --features="wasm"
+        run: cargo check --target wasm32-wasip1
+
+  wasm32-unknown-unknown-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: wasm32-unknown-unknown
+      - name: Check wasm32-unknown-unknown compilation
+        run: cargo check --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # WASM operations
 wasmer = { version = "6.0.1", default-features = false }
-wasmer-wasix = { version = "0.600.1", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
 num = { version = "0.4.3" }
 num-traits = { version = "0.2.16", default-features = false }
@@ -65,8 +64,8 @@ name = "groth16"
 harness = false
 
 [features]
-default = ["wasmer/default", "ethereum", "wasmer-wasix/default"]
-wasm = ["wasmer/js-default", "wasmer-wasix/js"]
+default = ["wasmer/default", "ethereum"]
+wasm = ["wasmer/js-default"]
 bench-complex-all = []
 ethereum = ["ethers-core"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,13 @@ resolver = "2"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[dependencies]
 # WASM operations
-wasmer = { version = "6.0.1", default-features = false }
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+wasmer = { version = "6.1.0-rc.3", default-features = false, features = ["default"] }
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasmer = { version = "6.1.0-rc.3", default-features = false, features = ["js-default"] }
+
+[dependencies]
 fnv = { version = "1.0.7", default-features = false }
 num = { version = "0.4.3" }
 num-traits = { version = "0.2.16", default-features = false }
@@ -49,23 +53,21 @@ cfg-if = "1.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-[target.'cfg(not(all(target_arch = "wasm32", target_os = "wasi")))'.dependencies]
-socket2 = { version = "0.5.7", features = ["all"] }
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { version = "1.29.1", features = ["macros"] }
+ethers = "2.0.7"
+criterion = "0.7"
 
 [dev-dependencies]
-criterion = "0.7"
 hex-literal = "1.0"
-tokio = { version = "1.29.1", features = ["macros"] }
 serde_json = "1.0.94"
-ethers = "2.0.7"
 
 [[bench]]
 name = "groth16"
 harness = false
 
 [features]
-default = ["wasmer/default", "ethereum"]
-wasm = ["wasmer/js-default"]
+default = ["ethereum"]
 bench-complex-all = []
 ethereum = ["ethers-core"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # WASM operations
-wasmer = { version = "6.1.0-rc.2", default-features = false }
-wasmer-wasix = { version = "=0.601.0-rc.2", default-features = false }
-# Hack until new version of `wasmer` releases.
-
-
+wasmer = { version = "6.0.1", default-features = false }
+wasmer-wasix = { version = "0.600.1", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
 num = { version = "0.4.3" }
 num-traits = { version = "0.2.16", default-features = false }

--- a/src/circom/circuit.rs
+++ b/src/circom/circuit.rs
@@ -91,8 +91,8 @@ mod tests {
     use ark_bn254::Fr;
     use ark_relations::gr1cs::ConstraintSystem;
 
-    #[tokio::test]
-    async fn satisfied() {
+    #[test]
+    fn satisfied() {
         let cfg = CircomConfig::<Fr>::new(
             "./test-vectors/mycircuit_js/mycircuit.wasm",
             "./test-vectors/mycircuit.r1cs",

--- a/src/witness/circom.rs
+++ b/src/witness/circom.rs
@@ -1,10 +1,9 @@
 use color_eyre::Result;
-use wasmer::{Exports, Function, Memory, Store, Value};
+use wasmer::{Function, Instance, Store, Value};
 
 #[derive(Debug)]
 pub struct Wasm {
-    pub exports: Exports,
-    pub memory: Memory,
+    pub instance: Instance,
 }
 
 impl Wasm {
@@ -65,14 +64,15 @@ impl Wasm {
     }
 
     fn func(&self, name: &str) -> &Function {
-        self.exports
+        self.instance
+            .exports
             .get_function(name)
             .unwrap_or_else(|_| panic!("function {name} not found"))
     }
 }
 
 impl Wasm {
-    pub fn new(exports: Exports, memory: Memory) -> Self {
-        Self { exports, memory }
+    pub fn new(instance: Instance) -> Self {
+        Self { instance }
     }
 }

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -80,9 +80,7 @@ impl WitnessCalculator {
             }
         };
         let instance = Instance::new(store, &module, &import_object)?;
-        let exports = instance.exports.clone();
-        let wasm = Wasm::new(exports, memory);
-        Ok(wasm)
+        Ok(Wasm::new(instance))
     }
 
     pub fn new_from_wasm(store: &mut Store, instance: Wasm) -> Result<Self> {

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -252,8 +252,8 @@ mod tests {
         path.to_string_lossy().to_string()
     }
 
-    #[tokio::test]
-    async fn multiplier_1() {
+    #[test]
+    fn multiplier_1() {
         run_test(TestCase {
             circuit_path: root_path("test-vectors/mycircuit_js/mycircuit.wasm").as_str(),
             inputs_path: root_path("test-vectors/mycircuit-input1.json").as_str(),
@@ -262,8 +262,8 @@ mod tests {
         });
     }
 
-    #[tokio::test]
-    async fn multiplier_2() {
+    #[test]
+    fn multiplier_2() {
         run_test(TestCase {
             circuit_path: root_path("test-vectors/mycircuit_js/mycircuit.wasm").as_str(),
             inputs_path: root_path("test-vectors/mycircuit-input2.json").as_str(),
@@ -277,8 +277,8 @@ mod tests {
         });
     }
 
-    #[tokio::test]
-    async fn multiplier_3() {
+    #[test]
+    fn multiplier_3() {
         run_test(TestCase {
             circuit_path: root_path("test-vectors/mycircuit_js/mycircuit.wasm").as_str(),
             inputs_path: root_path("test-vectors/mycircuit-input3.json").as_str(),
@@ -292,8 +292,8 @@ mod tests {
         });
     }
 
-    #[tokio::test]
-    async fn safe_multipler() {
+    #[test]
+    fn safe_multipler() {
         let witness =
             std::fs::read_to_string(root_path("test-vectors/safe-circuit-witness.json")).unwrap();
         let witness: Vec<String> = serde_json::from_str(&witness).unwrap();

--- a/src/zkey.rs
+++ b/src/zkey.rs
@@ -839,8 +839,8 @@ mod tests {
         G2Affine::from(G2Projective::new(x, y, z))
     }
 
-    #[tokio::test]
-    async fn verify_proof_with_zkey_with_r1cs() {
+    #[test]
+    fn verify_proof_with_zkey_with_r1cs() {
         let path = "./test-vectors/test.zkey";
         let mut file = File::open(path).unwrap();
         let (params, _matrices) = read_zkey(&mut file).unwrap(); // binfile.proving_key().unwrap();
@@ -867,8 +867,8 @@ mod tests {
         assert!(verified);
     }
 
-    #[tokio::test]
-    async fn verify_proof_with_zkey_without_r1cs() {
+    #[test]
+    fn verify_proof_with_zkey_without_r1cs() {
         let path = "./test-vectors/test.zkey";
         let mut file = File::open(path).unwrap();
         let (params, matrices) = read_zkey(&mut file).unwrap();

--- a/tests/groth16.rs
+++ b/tests/groth16.rs
@@ -8,8 +8,8 @@ use ark_groth16::Groth16;
 
 type GrothBn = Groth16<Bn254>;
 
-#[tokio::test]
-async fn groth16_proof() -> Result<()> {
+#[test]
+fn groth16_proof() -> Result<()> {
     let cfg = CircomConfig::<Fr>::new(
         "./test-vectors/mycircuit_js/mycircuit.wasm",
         "./test-vectors/mycircuit.r1cs",
@@ -39,8 +39,8 @@ async fn groth16_proof() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn groth16_proof_wrong_input() -> Result<()> {
+#[test]
+fn groth16_proof_wrong_input() -> Result<()> {
     let cfg = CircomConfig::<Fr>::new(
         "./test-vectors/mycircuit_js/mycircuit.wasm",
         "./test-vectors/mycircuit.r1cs",
@@ -72,8 +72,8 @@ async fn groth16_proof_wrong_input() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn groth16_proof_circom() -> Result<()> {
+#[test]
+fn groth16_proof_circom() -> Result<()> {
     let cfg = CircomConfig::<Fr>::new(
         "test-vectors/circuit2_js/circuit2.wasm",
         "test-vectors/circuit2.r1cs",
@@ -103,8 +103,8 @@ async fn groth16_proof_circom() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn witness_generation_circom() -> Result<()> {
+#[test]
+fn witness_generation_circom() -> Result<()> {
     let cfg = CircomConfig::<Fr>::new(
         "test-vectors/circuit2_js/circuit2.wasm",
         "test-vectors/circuit2.r1cs",

--- a/tests/solidity.rs
+++ b/tests/solidity.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
 use ark_circom::{CircomBuilder, CircomConfig, ethereum};
 use ark_std::rand::thread_rng;
 use color_eyre::Result;


### PR DESCRIPTION
This PR cleans up the dependencies of `ark-circom` and addresses the following issues:
- #88 is fixed by tweaking the conditional compilation flags, so that dependencies that are only used in tests will not be compiled for both `wasm32-wasip1` and `wasm32-unknown-unknown`
- The [CI error](https://github.com/arkworks-rs/circom-compat/actions/runs/16978777763/job/48134122944) is fixed by bumping `wasmer` from `6.1.0-rc.2` to `6.1.0-rc.3`

Furthermore, some improvements on code quality are made by:
- Removing the unused dependency `wasmer-wasix`
- Removing the `wasm` feature in favor of conditional compilation
- Removing unnecessary `async`  keywords
- Refactoring the `Wasm` struct