### PR TITLE
Add missing printDebug wasm runtime function

### DIFF
--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -77,6 +77,7 @@ impl WitnessCalculator {
                 "showSharedRWMemory" => runtime::show_memory(store),
                 "printErrorMessage" => runtime::print_error_message(store),
                 "writeBufferMessage" => runtime::write_buffer_message(store),
+                "printDebug" => runtime::print_debug(store),
             }
         };
         let instance = Instance::new(store, &module, &import_object)?;
@@ -228,6 +229,12 @@ mod runtime {
     }
 
     pub fn log_component(store: &mut Store) -> Function {
+        #[allow(unused)]
+        fn func(a: i32) {}
+        Function::new_typed(store, func)
+    }
+
+    pub fn print_debug(store: &mut Store) -> Function {
         #[allow(unused)]
         fn func(a: i32) {}
         Function::new_typed(store, func)


### PR DESCRIPTION
I guess this function is now required by the circom runtime as of version `2.2`. I discovered this when trying to run and received the following error:

```
thread 'main' panicked at /home/martyall/.cargo/git/checkouts/circom-compat-f8dd94f015257c55/09e92d4/src/circom/builder.rs:31:61:
called `Result::unwrap()` on an `Err` value: Error while importing "runtime"."printDebug": unknown import. Expected Function(FunctionType { params: [I32], results: [] })

```

fixes #https://github.com/arkworks-rs/circom-compat/issues/78 